### PR TITLE
Boost regex migration

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: polonius
 Priority: optional
 Maintainer: rail5 <andrew@rail5.org>
-Build-Depends: debhelper (>= 8.0.0), libncurses-dev
+Build-Depends: debhelper (>= 8.0.0), libncurses-dev, libboost-regex1.81-dev
 Standards-Version: 3.9.3
 Section: utils
 

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 3.9.3
 Section: utils
 
 Package: polonius
-Version: 0.3
+Version: 0.5
 License: GPL-3.0
 Vendor: rail5 <andrew@rail5.org>
 Priority: optional

--- a/edit/makefile
+++ b/edit/makefile
@@ -1,5 +1,5 @@
 CXX=g++
-PARAMS=-O2 -s
+PARAMS=-O2 -s -lboost_regex
 
 all:
 	$(CXX) -std=gnu++20 -o bin/polonius-editor $(PARAMS) src/main.cpp

--- a/edit/src/includes.h
+++ b/edit/src/includes.h
@@ -58,7 +58,7 @@
 /* Needed for process_bytecodes() function */
 #ifndef REGEX
 	#define REGEX
-	#include <regex>
+	#include <boost/regex.hpp>
 #endif
 
 

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ WIKIDIRECTORY=polonius.wiki
 WIKIUPSTREAM=https://github.com/rail5/polonius.wiki.git
 VERSION=$$(dpkg-parsechangelog -l debian/changelog --show-field version)
 
-all: update-version reader editor curses
+all: update-version reader editor
 
 update-version:
 	# Read the latest version number from debian/changelog

--- a/read/makefile
+++ b/read/makefile
@@ -1,21 +1,8 @@
 CXX=g++
-PARAMS=-O2 -s
-MAYBE_SPLIT_STACK=-fsplit-stack
+PARAMS=-O2 -s -lboost_regex
 
-all: clean check build
-
-check:
-	# Check if we can use -fsplit-stack
-	$(eval MAYBE_SPLIT_STACK=$(shell rm -rf checks; \
-	mkdir checks; \
-	echo "int main() { return 0; }" > checks/trivial_program.cpp; \
-	$(CXX) -o checks/trivial_program -fsplit-stack checks/trivial_program.cpp \
-	&& echo "-fsplit-stack" \
-	|| echo "-Dno_split_stack"))
-	rm -rf checks
-
-build:
-	$(CXX) -std=gnu++20 -o bin/polonius-reader $(PARAMS) $(MAYBE_SPLIT_STACK) src/main.cpp
+all:
+	$(CXX) -std=gnu++20 -o bin/polonius-reader $(PARAMS) src/main.cpp
 
 clean:
 	rm -f bin/polonius-reader

--- a/read/src/class_file.cpp
+++ b/read/src/class_file.cpp
@@ -144,7 +144,7 @@ bool reader::file::do_normal_search() {
 
 bool reader::file::do_regex_search() {
 	/***
-		A std::regex search in Polonius should happen this way:
+		A regex search in Polonius should happen this way:
 			0. Validate the regular expression (TODO: expression currently not validated before running)
 			1. Parse the regular expression into its component parts
 				e.g.:
@@ -173,7 +173,7 @@ bool reader::file::do_regex_search() {
 			Final:
 				Report the found match
 			
-		One important restriction is that we will be limited to finding std::regex matches no longer than the user-specified block size
+		One important restriction is that we will be limited to finding regex matches no longer than the user-specified block size
 			(default 10KB)
 		
 		TODO:
@@ -216,15 +216,15 @@ bool reader::file::do_regex_search() {
 		}
 		
 		std::string block_data = read(current_index, block_size);
-		std::smatch regex_search_result;
-		std::regex expression(search_query, std::regex::optimize);
+		boost::smatch regex_search_result;
+		boost::regex expression(search_query);
 
 		bool full_match_found = regex_search(block_data, regex_search_result, expression);
 		
 		if (!full_match_found) {
 			for (int64_t j = 0; j < sub_expressions.size(); j++) {
-				std::smatch sub_expression_search_result;
-				std::regex sub_expression(sub_expressions[j] + R"($)"); // 'R"($)"' signifies that the std::string must END with the match
+				boost::smatch sub_expression_search_result;
+				boost::regex sub_expression(sub_expressions[j] + R"($)"); // 'R"($)"' signifies that the std::string must END with the match
 
 				// Partial match found?
 				bool partial_match_found = regex_search(block_data, sub_expression_search_result, sub_expression);

--- a/read/src/class_file.cpp
+++ b/read/src/class_file.cpp
@@ -199,12 +199,6 @@ bool reader::file::do_regex_search() {
 	int64_t match_start = 0;
 	int64_t match_end = 0;
 
-	#ifdef no_split_stack
-	std::cerr << "polonius-reader: Warning!" << std::endl;
-	std::cerr << "polonius-reader: Your system architecture has a known bug with regex searches" << std::endl;
-	std::cerr << "polonius-reader: If the search fails, try again with a smaller block size (-b)" << std::endl;
-	#endif
-
 	std::vector<std::string> sub_expressions = create_sub_expressions(search_query);
 
 	for (int64_t current_index = start_position; current_index < end_position; (current_index = current_index + block_size)) {

--- a/read/src/includes.h
+++ b/read/src/includes.h
@@ -35,10 +35,10 @@
 	#define SYS_STAT
 	#include <sys/stat.h>
 #endif
-/* Needed for process_bytecodes() function */
+/* Needed for process_bytecodes() function and for regex searches */
 #ifndef REGEX
 	#define REGEX
-	#include <regex>
+	#include <boost/regex.hpp>
 #endif
 
 /* Shared definitions */

--- a/shared/parse_regex.cpp
+++ b/shared/parse_regex.cpp
@@ -4,7 +4,7 @@
 
 #ifndef REGEX
 	#define REGEX
-	#include <regex>
+	#include <boost/regex.hpp>
 #endif
 
 #ifndef VECTOR

--- a/shared/process_bytecodes.cpp
+++ b/shared/process_bytecodes.cpp
@@ -4,7 +4,7 @@
 
 #ifndef REGEX
 	#define REGEX
-	#include <regex>
+	#include <boost/regex.hpp>
 #endif
 #ifndef SSTREAM
 	#define SSTREAM
@@ -18,10 +18,10 @@ std::string process_bytecodes(std::string input) {
 		
 		Returns the string with all byte-codes converted to the actual bytes they represent
 	***/
-	std::regex expression("(\\\\x)([a-fA-F0-9]{2})"); // Matches \x00 through \xFF
+	boost::regex expression("(\\\\x)([a-fA-F0-9]{2})"); // Matches \x00 through \xFF
 
-	while (std::regex_search(input, expression)) {
-		std::istringstream isolated_hex_code(std::regex_replace(input, expression, "$2", std::regex_constants::format_no_copy | std::regex_constants::format_first_only)); // Isolate the first match and copy it into a stringstream
+	while (boost::regex_search(input, expression)) {
+		std::istringstream isolated_hex_code(boost::regex_replace(input, expression, "$2", boost::regex_constants::format_no_copy | boost::regex_constants::format_first_only)); // Isolate the first match and copy it into a stringstream
 
 		unsigned char real_byte;
 
@@ -33,7 +33,7 @@ std::string process_bytecodes(std::string input) {
 
 		std::string string_real_byte(1, static_cast<char>(real_byte)); // Move said byte into a 1-character string
 
-		input = std::regex_replace(input, expression, string_real_byte, std::regex_constants::format_first_only);
+		input = boost::regex_replace(input, expression, string_real_byte, boost::regex_constants::format_first_only);
 	}
 
 	return input;


### PR DESCRIPTION
Moving from std::regex to boost::regex

GNU's std::regex implementation has a tendency to overflow the stack. Switching to boost::regex solves this problem

This finally closes #29 